### PR TITLE
WIP: Make Linear Vestings Pausable

### DIFF
--- a/src/abis/vesting.json
+++ b/src/abis/vesting.json
@@ -1,5 +1,13 @@
 [
   {
+    "constant": false,
+    "inputs": [],
+    "name": "resume",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+  },
+  {
     "constant": true,
     "inputs": [],
     "name": "duration",
@@ -10,7 +18,6 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -24,7 +31,19 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "delayed",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
     "type": "function"
   },
   {
@@ -38,7 +57,19 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "pausable",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
     "type": "function"
   },
   {
@@ -52,7 +83,14 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "unpause",
+    "outputs": [],
+    "payable": false,
     "type": "function"
   },
   {
@@ -66,7 +104,6 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -80,7 +117,19 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "paused",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
     "type": "function"
   },
   {
@@ -94,7 +143,78 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "pause",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "release",
+    "outputs": [],
+    "payable": false,
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "revocable",
+    "outputs": [
+      {
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "payable": false,
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "released",
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "name": "_token",
+        "type": "address"
+      },
+      {
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "releaseForeignToken",
+    "outputs": [],
+    "payable": false,
     "type": "function"
   },
   {
@@ -121,6 +241,10 @@
         "type": "uint256"
       },
       {
+        "name": "_pausable",
+        "type": "bool"
+      },
+      {
         "name": "_revocable",
         "type": "bool"
       },
@@ -132,76 +256,6 @@
     "name": "initialize",
     "outputs": [],
     "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [],
-    "name": "release",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "revocable",
-    "outputs": [
-      {
-        "name": "",
-        "type": "bool"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "owner",
-    "outputs": [
-      {
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": true,
-    "inputs": [],
-    "name": "released",
-    "outputs": [
-      {
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "payable": false,
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "constant": false,
-    "inputs": [
-      {
-        "name": "_token",
-        "type": "address"
-      },
-      {
-        "name": "amount",
-        "type": "uint256"
-      }
-    ],
-    "name": "releaseForeignToken",
-    "outputs": [],
-    "payable": false,
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -210,7 +264,6 @@
     "name": "revoke",
     "outputs": [],
     "payable": false,
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -224,7 +277,6 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -238,7 +290,6 @@
     "name": "releaseTo",
     "outputs": [],
     "payable": false,
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -252,7 +303,6 @@
     "name": "changeBeneficiary",
     "outputs": [],
     "payable": false,
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -266,7 +316,6 @@
     "name": "transferOwnership",
     "outputs": [],
     "payable": false,
-    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
@@ -280,8 +329,25 @@
       }
     ],
     "payable": false,
-    "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "anonymous": false,
+    "inputs": [],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "name": "delay",
+        "type": "uint256"
+      }
+    ],
+    "name": "Resumed",
+    "type": "event"
   },
   {
     "anonymous": false,


### PR DESCRIPTION
The DAO uses vesting contracts to pay for 6-months grants. At the moment if a project falls behind schedule or there are any doubts about the project's leadership, the vesting contract is revoked preemptively and later recreated if the project catches up.

However, revoking a vesting contract has a very bad connotation and adds operational labor to resume it when necessary. Therefore this PR adds the functionality to pause and resume the vesting schedule.

* The contract can be declared pausable on creation.
* The owner can `pause` the vesting schedule.
* The owner can `unpause` the vesting without affecting schedule.
* The owner can `resume` the vesting considering the delay into the vesting schedule.

## Progress
* [X] Write Contract
* [ ] Write Tests
* [ ] Update UI
* [ ] Audit Changes

*Note: This PR might be moved to [feat/token-vesting-v2 branch](https://github.com/decentraland/vestings-builder/tree/feat/token-vesting-v2) to use hardhat environment.*

