### PR TITLE
feat: Implement OZ PausableUpgradeable

### DIFF
--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -3,10 +3,11 @@
 pragma solidity ^0.8.17;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-contract PeriodicTokenVesting is OwnableUpgradeable {
+contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     using SafeERC20 for IERC20;
 
     address private beneficiary;
@@ -61,6 +62,9 @@ contract PeriodicTokenVesting is OwnableUpgradeable {
         // Set the owner using the OwnableUpgradeable functions.
         __Ownable_init();
         transferOwnership(_owner);
+
+        // Initialize the Pausable contract.
+        __Pausable_init();
 
         // Set the rest of the initialization parameters
         _setBeneficiary(_beneficiary);
@@ -294,6 +298,17 @@ contract PeriodicTokenVesting is OwnableUpgradeable {
         emit ReleasedSurplus(_receiver, _amount);
 
         token.safeTransfer(_receiver, _amount);
+    }
+
+    /// @notice Pause the vesting.
+    /// Similar to revoking the vesting but reversible.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpause the vesting.
+    function unpause() external onlyOwner {
+        _unpause();
     }
 
     function _setBeneficiary(address _beneficiary) private {

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -217,7 +217,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
             "PeriodicTokenVesting#release: INVALID_RECEIVER"
         );
 
-        require(_amount > 0, "PeriodicTokenVesting#release: INVALID_AMOUNT");
+        require(_amount != 0, "PeriodicTokenVesting#release: INVALID_AMOUNT");
 
         uint256 releasable = getReleasable();
 
@@ -266,7 +266,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         );
 
         require(
-            _amount > 0,
+            _amount != 0,
             "PeriodicTokenVesting#releaseForeignToken: INVALID_AMOUNT"
         );
 

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -130,6 +130,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     }
 
     /// @notice Get if the vesting is paused.
+    /// @dev Returns the same PausableUpgradeable.paused() but the function has a name like the rest of the getters.
     /// @return If the vesting is paused.
     function getIsPaused() external view returns (bool) {
         return paused();

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -129,16 +129,16 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         return revokedTimestamp;
     }
 
-    /// @notice Get the amount of releasable tokens.
-    /// @return The amount of releasable tokens.
-    function getReleasable() public view returns (uint256) {
-        return getVested() - released;
-    }
-
     /// @notice Get if the vesting is paused.
     /// @return If the vesting is paused.
     function getIsPaused() external view returns (bool) {
         return paused();
+    }
+
+    /// @notice Get the amount of releasable tokens.
+    /// @return The amount of releasable tokens.
+    function getReleasable() public view returns (uint256) {
+        return getVested() - released;
     }
 
     /// @notice Get the total amount of tokens that will be vested in this contract.

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -13,6 +13,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     address private beneficiary;
     IERC20 private token;
     bool private isRevocable;
+    bool private isPausable;
     uint256 private start;
     uint256 private periodDuration;
     uint256[] private vestedPerPeriod;
@@ -57,6 +58,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     /// @param _beneficiary The beneficiary of the vested tokens.
     /// @param _token The token to vest.
     /// @param _isRevocable Whether the vesting contract is revocable.
+    /// @param _isPausable Whether the vesting contract is pausable.
     /// @param _start The start time of the vesting.
     /// @param _periodDuration The duration of each period.
     /// @param _vestedPerPeriod The amount of tokens vested per period.
@@ -65,6 +67,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         address _beneficiary,
         address _token,
         bool _isRevocable,
+        bool _isPausable,
         uint256 _start,
         uint256 _periodDuration,
         uint256[] calldata _vestedPerPeriod
@@ -82,6 +85,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         _setPeriodDuration(_periodDuration);
         _setVestedPerPeriod(_vestedPerPeriod);
         isRevocable = _isRevocable;
+        isPausable = _isPausable;
         start = _start;
     }
 
@@ -101,6 +105,12 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     /// @return Whether the vesting contract is revocable.
     function getIsRevocable() external view returns (bool) {
         return isRevocable;
+    }
+
+    /// @notice Get whether the vesting contract is pausable.
+    /// @return Whether the vesting contract is pausable.
+    function getIsPausable() external view returns (bool) {
+        return isPausable;
     }
 
     /// @notice Get the start time of the vesting.
@@ -321,6 +331,8 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     /// @notice Pause the vesting.
     /// Similar to revoking the vesting but reversible.
     function pause() external onlyOwner whenNotRevoked {
+        require(isPausable, "PeriodicTokenVesting#pause: NON_PAUSABLE");
+
         stopTimestamp = block.timestamp;
 
         _pause();

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -135,6 +135,12 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         return getVested() - released;
     }
 
+    /// @notice Get if the vesting is paused.
+    /// @return If the vesting is paused.
+    function getIsPaused() external view returns (bool) {
+        return paused();
+    }
+
     /// @notice Get the total amount of tokens that will be vested in this contract.
     /// @return The total amount of tokens that will be vested in this contract.
     function getTotal() public view returns (uint256) {

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -37,6 +37,14 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         _;
     }
 
+    modifier whenNotRevoked() {
+        require(
+            revokedTimestamp == 0,
+            "PeriodicTokenVesting#whenNotRevoked: IS_REVOKED"
+        );
+        _;
+    }
+
     constructor() {
         // Prevent the implementation from being initialized.
         _disableInitializers();
@@ -302,12 +310,12 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
 
     /// @notice Pause the vesting.
     /// Similar to revoking the vesting but reversible.
-    function pause() external onlyOwner {
+    function pause() external onlyOwner whenNotRevoked {
         _pause();
     }
 
     /// @notice Unpause the vesting.
-    function unpause() external onlyOwner {
+    function unpause() external onlyOwner whenNotRevoked {
         _unpause();
     }
 

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -131,13 +131,6 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         return stopTimestamp;
     }
 
-    /// @notice Get if the vesting is paused.
-    /// @dev Returns the same PausableUpgradeable.paused() but the function has a name like the rest of the getters.
-    /// @return If the vesting is paused.
-    function getIsPaused() external view returns (bool) {
-        return paused();
-    }
-
     /// @notice Get if the vesting is revoked.
     /// @return If the vesting is revoked.
     function getIsRevoked() public view returns (bool) {

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -215,9 +215,9 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
             "PeriodicTokenVesting#release: INVALID_RECEIVER"
         );
 
-        uint256 releasable = getReleasable();
-
         require(_amount > 0, "PeriodicTokenVesting#release: INVALID_AMOUNT");
+
+        uint256 releasable = getReleasable();
 
         require(
             _amount <= releasable,

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -29,6 +29,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
     );
     event ReleasedSurplus(address indexed _receiver, uint256 _amount);
 
+    /// @dev Indicates that only the beneficiary can call the function.
     modifier onlyBeneficiary() {
         require(
             _msgSender() == beneficiary,
@@ -37,6 +38,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         _;
     }
 
+    /// @dev Indicates that the function can be called when the contract is not revoked.
     modifier whenNotRevoked() {
         require(
             !getIsRevoked(),

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -22,5 +22,13 @@ module.exports = {
   gasReporter: {
     enabled: true,
   },
-  solidity: "0.8.17",
+  solidity: {
+    version: "0.8.17",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
 };

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -449,11 +449,11 @@ describe("PeriodicTokenVesting", () => {
     });
 
     it("should pause the vesting", async () => {
-      expect(await vesting.paused()).to.be.false;
+      expect(await vesting.getIsPaused()).to.be.false;
 
       await vesting.connect(owner).pause();
 
-      expect(await vesting.paused()).to.be.true;
+      expect(await vesting.getIsPaused()).to.be.true;
     });
 
     it("should emit a Paused event", async () => {
@@ -487,11 +487,11 @@ describe("PeriodicTokenVesting", () => {
     it("should unpause the vesting", async () => {
       await vesting.connect(owner).pause();
 
-      expect(await vesting.paused()).to.be.true;
+      expect(await vesting.getIsPaused()).to.be.true;
 
       await vesting.connect(owner).unpause();
 
-      expect(await vesting.paused()).to.be.false;
+      expect(await vesting.getIsPaused()).to.be.false;
     });
 
     it("should emit an Unpaused event", async () => {

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -527,11 +527,11 @@ describe("PeriodicTokenVesting", () => {
     });
 
     it("should pause the vesting", async () => {
-      expect(await vesting.getIsPaused()).to.be.false;
+      expect(await vesting.paused()).to.be.false;
 
       await vesting.connect(owner).pause();
 
-      expect(await vesting.getIsPaused()).to.be.true;
+      expect(await vesting.paused()).to.be.true;
     });
 
     it("should emit a Paused event", async () => {
@@ -573,11 +573,11 @@ describe("PeriodicTokenVesting", () => {
     it("should unpause the vesting", async () => {
       await vesting.connect(owner).pause();
 
-      expect(await vesting.getIsPaused()).to.be.true;
+      expect(await vesting.paused()).to.be.true;
 
       await vesting.connect(owner).unpause();
 
-      expect(await vesting.getIsPaused()).to.be.false;
+      expect(await vesting.paused()).to.be.false;
     });
 
     it("should emit an Unpaused event", async () => {

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -465,6 +465,14 @@ describe("PeriodicTokenVesting", () => {
     it("reverts when the caller is not the owner", async () => {
       await expect(vesting.connect(extra).pause()).to.be.revertedWith("Ownable: caller is not the owner");
     });
+
+    it("reverts when the vesting is revoked", async () => {
+      await vesting.connect(owner).revoke();
+
+      await expect(vesting.connect(owner).pause()).to.be.revertedWith(
+        "PeriodicTokenVesting#whenNotRevoked: IS_REVOKED"
+      );
+    });
   });
 
   describe("unpause", () => {
@@ -488,6 +496,14 @@ describe("PeriodicTokenVesting", () => {
 
     it("reverts when the caller is not the owner", async () => {
       await expect(vesting.connect(extra).unpause()).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+
+    it("reverts when the vesting is revoked", async () => {
+      await vesting.connect(owner).revoke();
+
+      await expect(vesting.connect(owner).unpause()).to.be.revertedWith(
+        "PeriodicTokenVesting#whenNotRevoked: IS_REVOKED"
+      );
     });
   });
 });

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -442,4 +442,52 @@ describe("PeriodicTokenVesting", () => {
       );
     });
   });
+
+  describe("pause", () => {
+    beforeEach(async () => {
+      await vesting.initialize(...initParamsList);
+    });
+
+    it("should pause the vesting", async () => {
+      expect(await vesting.paused()).to.be.false;
+
+      await vesting.connect(owner).pause();
+
+      expect(await vesting.paused()).to.be.true;
+    });
+
+    it("reverts when the contract is already paused", async () => {
+      await vesting.connect(owner).pause();
+
+      await expect(vesting.connect(owner).pause()).to.be.revertedWith("Pausable: paused");
+    });
+
+    it("reverts when the caller is not the owner", async () => {
+      await expect(vesting.connect(extra).pause()).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+  });
+
+  describe("unpause", () => {
+    beforeEach(async () => {
+      await vesting.initialize(...initParamsList);
+    });
+
+    it("should unpause the vesting", async () => {
+      await vesting.connect(owner).pause();
+
+      expect(await vesting.paused()).to.be.true;
+
+      await vesting.connect(owner).unpause();
+
+      expect(await vesting.paused()).to.be.false;
+    });
+
+    it("reverts when the contract is not paused", async () => {
+      await expect(vesting.connect(owner).unpause()).to.be.revertedWith("Pausable: not paused");
+    });
+
+    it("reverts when the caller is not the owner", async () => {
+      await expect(vesting.connect(extra).unpause()).to.be.revertedWith("Ownable: caller is not the owner");
+    });
+  });
 });

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -456,6 +456,10 @@ describe("PeriodicTokenVesting", () => {
       expect(await vesting.paused()).to.be.true;
     });
 
+    it("should emit a Paused event", async () => {
+      await expect(vesting.connect(owner).pause()).to.emit(vesting, "Paused").withArgs(owner.address);
+    });
+
     it("reverts when the contract is already paused", async () => {
       await vesting.connect(owner).pause();
 
@@ -488,6 +492,12 @@ describe("PeriodicTokenVesting", () => {
       await vesting.connect(owner).unpause();
 
       expect(await vesting.paused()).to.be.false;
+    });
+
+    it("should emit an Unpaused event", async () => {
+      await vesting.connect(owner).pause();
+
+      await expect(vesting.connect(owner).unpause()).to.emit(vesting, "Unpaused").withArgs(owner.address);
     });
 
     it("reverts when the contract is not paused", async () => {


### PR DESCRIPTION
Closes #46 

Pausing acts similar to revoke with the difference that it is reversible. 
Unpausing will let the vesting continue as usual.

- Integrate OZ PausableUpgradable
- Determine if the contract is pausable with the isPausable initialization variable
- Rename revokeTimestamp to stopTimestamp to be used for both revoke and pause cases