### PR TITLE
feat: Linear struct

### DIFF
--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -207,8 +207,11 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         uint256 total;
 
         // Sum all the tokens vested per period to obtain the total amount.
-        for (uint i = 0; i < vestedPerPeriod.length; i++) {
+        for (uint i = 0; i < vestedPerPeriod.length; ) {
             total += vestedPerPeriod[i];
+            unchecked {
+                ++i;
+            }
         }
 
         return total;
@@ -248,8 +251,11 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         uint256 vested;
 
         // Add the vested amount for each period that has passed.
-        for (uint i = 0; i < elapsedPeriods; i++) {
+        for (uint i = 0; i < elapsedPeriods; ) {
             vested += vestedPerPeriod[i];
+            unchecked {
+                ++i;
+            }
         }
 
         // If the vesting was defined as linear, we have to obtain the amount of tokens vested

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -231,6 +231,7 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         }
 
         // If the current or stop timestamp was previous to the start time, nothing is vested.
+        // linear cliff duration is always 0 if the vesting is not linear.
         if (timestamp < start + linear.cliffDuration) {
             return 0;
         }

--- a/contracts/PeriodicTokenVesting.sol
+++ b/contracts/PeriodicTokenVesting.sol
@@ -231,7 +231,8 @@ contract PeriodicTokenVesting is OwnableUpgradeable, PausableUpgradeable {
         }
 
         // If the current or stop timestamp was previous to the start time, nothing is vested.
-        // linear cliff duration is always 0 if the vesting is not linear.
+        // Linear cliff duration is always 0 if the vesting is not linear.
+        // On non linear vestings, cliff duration can be simulated with periods that vest 0 tokens.
         if (timestamp < start + linear.cliffDuration) {
             return 0;
         }

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -568,7 +568,7 @@ describe("PeriodicTokenVesting", () => {
         .withArgs(extra.address, releaseAmount);
     });
 
-    it("should be able to release all tokens when more periods than the ones defined have passed", async () => {
+    it("should be able to release all tokens when all periods + 1 have elapsed", async () => {
       await token.connect(treasury).transfer(vesting.address, totalToVest);
 
       await helpers.time.setNextBlockTimestamp(

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -401,7 +401,7 @@ describe("PeriodicTokenVesting", () => {
       expect(await vesting.getVested()).to.equal("0");
     });
 
-    it("should return half the vested tokens of the first period with linear vesting", async () => {
+    it("should return half the vested tokens of the first period when half the first period has elapsed and the vesting is linear", async () => {
       await preInitSnapshot.restore();
 
       initParams.linear = [true, 0];
@@ -414,6 +414,51 @@ describe("PeriodicTokenVesting", () => {
       await helpers.mine();
 
       expect(await vesting.getVested()).to.equal(vestedPerPeriod[0].div(2));
+    });
+
+    it("should return 1/4 the vested tokens of the first period when 1/4 of the first period has elapsed and the vesting is linear", async () => {
+      await preInitSnapshot.restore();
+
+      initParams.linear = [true, 0];
+      initParamsList = Object.values(initParams);
+
+      await vesting.initialize(...initParamsList);
+
+      await helpers.time.setNextBlockTimestamp(initParams.start + initParams.periodDuration / 4);
+
+      await helpers.mine();
+
+      expect(await vesting.getVested()).to.equal(vestedPerPeriod[0].div(4));
+    });
+
+    it("should return 3/4 the vested tokens of the first period when 3/4 of the first period has elapsed and the vesting is linear", async () => {
+      await preInitSnapshot.restore();
+
+      initParams.linear = [true, 0];
+      initParamsList = Object.values(initParams);
+
+      await vesting.initialize(...initParamsList);
+
+      await helpers.time.setNextBlockTimestamp(initParams.start + (initParams.periodDuration / 4) * 3);
+
+      await helpers.mine();
+
+      expect(await vesting.getVested()).to.equal(vestedPerPeriod[0].div(4).mul(3));
+    });
+
+    it("should return all the vested tokens of the first period when the first period has elapsed and the vesting is linear", async () => {
+      await preInitSnapshot.restore();
+
+      initParams.linear = [true, 0];
+      initParamsList = Object.values(initParams);
+
+      await vesting.initialize(...initParamsList);
+
+      await helpers.time.setNextBlockTimestamp(initParams.start + initParams.periodDuration);
+
+      await helpers.mine();
+
+      expect(await vesting.getVested()).to.equal(vestedPerPeriod[0]);
     });
   });
 


### PR DESCRIPTION
The simplest way I've found to solve the linear issue is to have a separate cliffDuration variable for the linear vesting.

- initialize receives a _linear struct with enabled and cliffDuration properties.
- validates that cliffDuration can e different than 0 when enabled is true (useful in the getVested function)
- validates that the cliffDuration is not longer than the whole vesting.