### PR TITLE
feat: Save total in storage

### DIFF
--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -81,6 +81,7 @@ describe("PeriodicTokenVesting", () => {
       expect(await vesting.getPeriod()).to.equal(Zero);
       expect(await vesting.getCliff()).to.equal(Zero);
       expect(await vesting.getVestedPerPeriod()).to.be.empty;
+      expect(await vesting.getTotal()).to.equal(Zero);
     });
 
     it("should initialize values", async () => {
@@ -100,6 +101,7 @@ describe("PeriodicTokenVesting", () => {
       expect(await vesting.getPeriod()).to.equal(initParams.period);
       expect(await vesting.getCliff()).to.equal(initParams.cliff);
       expect(await vesting.getVestedPerPeriod()).to.have.same.deep.members(vestedPerPeriod);
+      expect(await vesting.getTotal()).to.equal(totalToVest);
     });
 
     it("should support 1250 periods with 1 million to vest each", async () => {

--- a/test/PeriodicTokenVesting.spec.js
+++ b/test/PeriodicTokenVesting.spec.js
@@ -898,6 +898,22 @@ describe("PeriodicTokenVesting", () => {
       expect(await token.balanceOf(extra.address)).to.equal(totalToVest);
     });
 
+    it("should release surplus tokens after the vesting has ended", async () => {
+      await token.connect(treasury).transfer(vesting.address, totalToVestDoubled);
+
+      expect(await token.balanceOf(vesting.address)).to.equal(totalToVestDoubled);
+      expect(await token.balanceOf(extra.address)).to.equal(Zero);
+
+      await helpers.time.setNextBlockTimestamp(
+        initParams.start + initParams.period * initParams.vestedPerPeriod.length
+      );
+
+      await vesting.connect(owner).releaseSurplus(extra.address, totalToVest);
+
+      expect(await token.balanceOf(vesting.address)).to.equal(totalToVestDoubled.sub(totalToVest));
+      expect(await token.balanceOf(extra.address)).to.equal(totalToVest);
+    });
+
     it("should emit a ReleasedSurplus event", async () => {
       await token.connect(treasury).transfer(vesting.address, totalToVestDoubled);
 


### PR DESCRIPTION
- Add total storage variable
- getTotal is now external
- internal getTotal usage is replaced by total storage variable
- total is assigned on initialization

Less gas consumption for `releaseSurplus`.

More gas consumption on `initialize`.

Initialize will always be called by the deployer of the contract, while releaseSurplus will only used on certain occasions.

However it will make external contract interactions with getTotal cheaper.